### PR TITLE
add selecticonstring and contextmenu support

### DIFF
--- a/SelectString/Clicker.cs
+++ b/SelectString/Clicker.cs
@@ -11,7 +11,7 @@ namespace SelectString
         Dictionary<string, long> ThrottleTimes = [];
         delegate void ReceiveEventDelegate(IntPtr addon, EventType evt, uint a3, IntPtr a4, IntPtr a5);
 
-        internal void ClickItemThrottled(IntPtr addonPtr, ushort index, string identifier)
+        internal void ClickItemThrottled(AddonMaster.SelectString addon, ushort index, string identifier)
         {
             if (ThrottleTimes.TryGetValue(identifier, out var time))
             {
@@ -23,7 +23,36 @@ namespace SelectString
             }
             ThrottleTimes[identifier] = Environment.TickCount64 + 500;
             Svc.Log.Information($"Click for {identifier} was processed.");
-            var addon = new AddonMaster.SelectString(addonPtr);
+            addon.Entries[index].Select();
+        }
+
+        internal void ClickItemThrottled(AddonMaster.SelectIconString addon, ushort index, string identifier)
+        {
+            if (ThrottleTimes.TryGetValue(identifier, out var time))
+            {
+                if (Environment.TickCount64 < time)
+                {
+                    Svc.Log.Information($"Click for {identifier} was throttled.");
+                    return;
+                }
+            }
+            ThrottleTimes[identifier] = Environment.TickCount64 + 500;
+            Svc.Log.Information($"Click for {identifier} was processed.");
+            addon.Entries[index].Select();
+        }
+
+        internal void ClickItemThrottled(AddonMaster.ContextMenu addon, ushort index, string identifier)
+        {
+            if (ThrottleTimes.TryGetValue(identifier, out var time))
+            {
+                if (Environment.TickCount64 < time)
+                {
+                    Svc.Log.Information($"Click for {identifier} was throttled.");
+                    return;
+                }
+            }
+            ThrottleTimes[identifier] = Environment.TickCount64 + 500;
+            Svc.Log.Information($"Click for {identifier} was processed.");
             addon.Entries[index].Select();
         }
     }


### PR DESCRIPTION
resolves (partially) #6 (I don't remember where `SelectionString` comes up)

requires https://github.com/NightmareXIV/ECommons/pull/64

selectstring and selecticonstring, despite being basically identical, aren't interchangeable via addonmaster so there's a lot of duplicated code there. This was kind of a lazy expansion

Context menu support only works for native entries (not dalamud added ones since those do not have callback values)